### PR TITLE
Add placeholder test report

### DIFF
--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -1,0 +1,3 @@
+# Test Report
+
+No runnable web application or build assets were found in the repository, so automated site audits (Lighthouse, Core Web Vitals, cross-browser/device checks, SEO validation) could not be executed. Please provide the deployable web project or build output so that the requested verification steps can be performed.


### PR DESCRIPTION
## Summary
- add a placeholder test report documenting that the requested audits could not be run because no runnable web app exists in the repository

## Testing
- not run (no runnable web application available)


------
https://chatgpt.com/codex/tasks/task_e_68e57ecc5c0c832ba286f5bc04af540c