### PR TITLE
Add share workflow with canvas score card

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GameArcade</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <header>
+      <h1>GameArcade</h1>
+      <p class="tagline">Mini arcade games on web and mobile.</p>
+    </header>
+
+    <section class="scoreboard">
+      <h2 id="game-name">Space Runner</h2>
+      <p class="score">Score: <span id="score-value">0</span></p>
+      <div class="actions">
+        <button id="play-btn" type="button">Simulate Score</button>
+        <button id="share-btn" type="button" disabled>Share Score</button>
+      </div>
+    </section>
+
+    <section id="share-result" class="share-result hidden" aria-live="polite">
+      <h3>Share your score</h3>
+      <p>Use the links below if your device does not support the native share dialog.</p>
+      <div class="share-links">
+        <a id="twitter-link" target="_blank" rel="noopener" class="share-link">Share on Twitter</a>
+        <a id="whatsapp-link" target="_blank" rel="noopener" class="share-link">Share on WhatsApp</a>
+      </div>
+      <label class="share-text-label" for="share-text">Copy text</label>
+      <textarea id="share-text" readonly></textarea>
+      <figure class="score-card">
+        <img id="score-card-image" alt="Score card preview" />
+        <figcaption>Generated share card preview</figcaption>
+      </figure>
+    </section>
+  </main>
+
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,14 @@
+export const analytics = {
+  /**
+   * Tracks a lightweight analytics event. Replace this with your
+   * analytics provider (Google Analytics, Segment, etc.).
+   * @param {string} eventName
+   * @param {Record<string, unknown>} payload
+   */
+  trackEvent(eventName, payload = {}) {
+    // For the purposes of this demo we log to the console.
+    // In production this could call an analytics SDK.
+    const timestamp = new Date().toISOString();
+    console.info(`[analytics:${eventName}]`, { ...payload, timestamp });
+  },
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,36 @@
+import { shareScore } from './share.js';
+
+const playButton = document.getElementById('play-btn');
+const shareButton = document.getElementById('share-btn');
+const scoreValue = document.getElementById('score-value');
+const gameNameEl = document.getElementById('game-name');
+
+let currentScore = 0;
+
+function getRandomScore() {
+  return Math.floor(Math.random() * 10_000);
+}
+
+function updateScore(score) {
+  currentScore = score;
+  scoreValue.textContent = score.toLocaleString();
+  shareButton.disabled = false;
+}
+
+function getGameName() {
+  return gameNameEl?.textContent?.trim() || 'Unknown Game';
+}
+
+playButton?.addEventListener('click', () => {
+  const newScore = getRandomScore();
+  updateScore(newScore);
+});
+
+shareButton?.addEventListener('click', async () => {
+  if (shareButton.disabled) return;
+  const gameName = getGameName();
+  await shareScore({ gameName, score: currentScore });
+});
+
+// Preload a score to demonstrate the UI.
+updateScore(getRandomScore());

--- a/src/share.js
+++ b/src/share.js
@@ -1,0 +1,158 @@
+import { analytics } from './analytics.js';
+
+const TWITTER_URL = 'https://twitter.com/intent/tweet';
+const WHATSAPP_URL = 'https://api.whatsapp.com/send';
+
+/**
+ * Generates a shareable score card image using Canvas.
+ * @param {string} gameName
+ * @param {number} score
+ * @returns {Promise<{ dataUrl: string, blob: Blob | null }>} The data url and blob for sharing.
+ */
+async function generateScoreCard(gameName, score) {
+  const width = 1200;
+  const height = 630;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, '#1d4ed8');
+  gradient.addColorStop(1, '#0f172a');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = '#f97316';
+  ctx.fillRect(60, 60, width - 120, height - 120);
+
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(90, 90, width - 180, height - 180);
+
+  ctx.fillStyle = '#f8fafc';
+  ctx.font = 'bold 72px "Segoe UI", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('GameArcade', width / 2, 220);
+
+  ctx.fillStyle = '#f97316';
+  ctx.font = '600 56px "Segoe UI", sans-serif';
+  ctx.fillText(gameName, width / 2, 320);
+
+  ctx.fillStyle = '#f8fafc';
+  ctx.font = 'bold 140px "Segoe UI", sans-serif';
+  ctx.fillText(`${score}`, width / 2, 470);
+
+  ctx.fillStyle = 'rgba(248, 250, 252, 0.75)';
+  ctx.font = '36px "Segoe UI", sans-serif';
+  ctx.fillText('Can you beat my score?', width / 2, 560);
+
+  const dataUrl = canvas.toDataURL('image/png');
+  let blob = null;
+  try {
+    const response = await fetch(dataUrl);
+    blob = await response.blob();
+  } catch (error) {
+    console.warn('Unable to convert score card to blob', error);
+  }
+
+  return { dataUrl, blob };
+}
+
+function buildShareText(gameName, score, shareUrl) {
+  return `${gameName} - Score: ${score} ${shareUrl}`;
+}
+
+function buildShareLinks(text) {
+  const encodedText = encodeURIComponent(text);
+  return {
+    twitter: `${TWITTER_URL}?text=${encodedText}`,
+    whatsapp: `${WHATSAPP_URL}?text=${encodedText}`,
+  };
+}
+
+function updateFallbackUI({
+  text,
+  links,
+  scoreCardUrl,
+}) {
+  const shareResult = document.getElementById('share-result');
+  const twitterLink = document.getElementById('twitter-link');
+  const whatsappLink = document.getElementById('whatsapp-link');
+  const shareText = document.getElementById('share-text');
+  const scoreCardImage = document.getElementById('score-card-image');
+
+  if (!shareResult || !twitterLink || !whatsappLink || !shareText || !scoreCardImage) {
+    return;
+  }
+
+  twitterLink.href = links.twitter;
+  whatsappLink.href = links.whatsapp;
+  shareText.value = text;
+  scoreCardImage.src = scoreCardUrl;
+  scoreCardImage.alt = `Score card for ${text}`;
+  shareResult.classList.remove('hidden');
+}
+
+function hideFallbackUI() {
+  const shareResult = document.getElementById('share-result');
+  if (shareResult) {
+    shareResult.classList.add('hidden');
+  }
+}
+
+async function shareNative({ gameName, score, shareUrl, scoreCard }) {
+  if (!navigator.share) {
+    return false;
+  }
+
+  const shareText = buildShareText(gameName, score, shareUrl);
+  const files = [];
+  if (scoreCard.blob && typeof File !== 'undefined') {
+    try {
+      const file = new File([scoreCard.blob], `${gameName}-score.png`, {
+        type: 'image/png',
+        lastModified: Date.now(),
+      });
+      if (!navigator.canShare || navigator.canShare({ files: [file] })) {
+        files.push(file);
+      }
+    } catch (error) {
+      console.warn('Unable to create score card file', error);
+    }
+  }
+
+  try {
+    if (files.length && navigator.canShare?.({ files })) {
+      await navigator.share({
+        title: `${gameName} score`,
+        text: shareText,
+        url: shareUrl,
+        files,
+      });
+    } else {
+      await navigator.share({
+        title: `${gameName} score`,
+        text: shareText,
+        url: shareUrl,
+      });
+    }
+    return true;
+  } catch (error) {
+    console.warn('Native share failed', error);
+    return false;
+  }
+}
+
+export async function shareScore({ gameName, score, shareUrl = window.location.href }) {
+  const scoreCard = await generateScoreCard(gameName, score);
+  const text = buildShareText(gameName, score, shareUrl);
+  const links = buildShareLinks(text);
+
+  analytics.trackEvent('share', { game: gameName, score });
+
+  hideFallbackUI();
+  const shared = await shareNative({ gameName, score, shareUrl, scoreCard });
+  if (!shared) {
+    updateFallbackUI({ text, links, scoreCardUrl: scoreCard.dataUrl });
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,184 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.7);
+  --accent: #f97316;
+  --accent-strong: #ea580c;
+  --text: #f8fafc;
+  --text-muted: rgba(248, 250, 252, 0.7);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1d4ed8, #0f172a 60%);
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.5rem;
+}
+
+.app {
+  width: min(680px, 100%);
+  background-color: var(--surface);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(12px);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 5vw, 3.25rem);
+  margin: 0;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  color: var(--text-muted);
+}
+
+.scoreboard {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 18px;
+  padding: 1.75rem;
+  text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.scoreboard h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.score {
+  margin: 0;
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  font-weight: 700;
+}
+
+.actions {
+  margin-top: 1.75rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: var(--text);
+  box-shadow: 0 10px 30px rgba(249, 115, 22, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px rgba(249, 115, 22, 0.5);
+}
+
+.share-result {
+  margin-top: 2.5rem;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 18px;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+}
+
+.share-result.hidden {
+  display: none;
+}
+
+.share-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.share-link {
+  color: var(--text);
+  text-decoration: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.35);
+  transition: background 0.2s ease;
+}
+
+.share-link:hover {
+  background: rgba(59, 130, 246, 0.55);
+}
+
+.share-text-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+#share-text {
+  width: 100%;
+  min-height: 80px;
+  padding: 0.85rem;
+  border-radius: 12px;
+  border: none;
+  resize: none;
+  font-size: 0.95rem;
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.score-card {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 18px;
+  padding: 1rem;
+  text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.score-card img {
+  width: 100%;
+  border-radius: 12px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
+}
+
+.score-card figcaption {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .app {
+    padding: 1.75rem;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a demo score screen with share controls and fallback messaging
- implement score sharing helper that uses the Web Share API with analytics tracking
- render a canvas-based score card image and expose Twitter/WhatsApp links when native share is unavailable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e57d9ba948832bb774d629980e43a5